### PR TITLE
Integrate signing + Nexus publish plugin for Maven Central release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.48'
+        classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
     }
 }
 
@@ -22,10 +23,42 @@ allprojects {
     }
 }
 
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
+
+apply from: "${rootDir}/sonatype.gradle"
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
 ext {
     libraryVersionName = '1.1.9-beta01'
+}
+
+// Distribution Packaging
+
+task cleanArchive(type: Delete) {
+    delete "$buildDir/Releases"
+}
+
+task cleanDistribution(type: Delete) {
+    delete "$buildDir"
+}
+
+task copyFilesForArchiving(type: Copy) {
+    from("$rootDir") {
+        include "${DISTRIBUTION_REPO}/**"
+    }
+    into "$buildDir/Releases"
+
+    dependsOn cleanArchive
+}
+
+task packageDistribution(type: Zip) {
+    destinationDirectory = file("$buildDir")
+
+    from "$buildDir/Releases"
+
+    dependsOn cleanDistribution
+    dependsOn copyFilesForArchiving
 }

--- a/gateway-android/build.gradle
+++ b/gateway-android/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
@@ -94,12 +95,11 @@ publishing {
     publications {
         aar(MavenPublication) {
             groupId = 'com.mastercard.gateway'
-            artifactId = project.name
+            artifactId project.name
             version = libraryVersionName
 
             afterEvaluate {
-                // Publish the default AAR output
-                artifact("$buildDir/outputs/aar/${project.name}-release.aar")
+                artifact bundleReleaseAar
                 artifact androidJavadocsJar
                 artifact androidSourcesJar
             }
@@ -147,4 +147,29 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven {
+            name = "distribution"
+            url = "$rootDir/$DISTRIBUTION_REPO"
+        }
+        // The repository to publish to, Sonatype/MavenCentral
+        maven {
+            name = "sonatype"
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+
+            credentials {
+                username ossrhUsername
+                password ossrhPassword
+            }
+        }
+    }
+
+}
+
+signing {
+    sign publishing.publications
+    sign configurations.archives
 }

--- a/sonatype.gradle
+++ b/sonatype.gradle
@@ -1,0 +1,36 @@
+// Create variables with empty default values
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.secretKeyRingFile"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+
+File secretPropsFile = project.rootProject.file('local.properties')
+if (secretPropsFile.exists()) {
+    println "Found secret props file, loading props"
+    Properties p = new Properties()
+    p.load(new FileInputStream(secretPropsFile))
+    p.each { name, value ->
+        ext[name] = value
+    }
+} else {
+    println "No props file, loading env vars"
+    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+    ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY')
+    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+}
+
+// Set up Sonatype repository
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+        }
+    }
+}


### PR DESCRIPTION
- Applied `io.github.gradle-nexus.publish-plugin` to automate release to Sonatype OSSRH
- Added `signing` configuration to generate PGP signatures for artifacts
- Configured `publishing` block to define Maven publications
- Integrated Nexus publishing setup with Sonatype credentials (username, password, staging profile)
